### PR TITLE
Fix code highlighting on example load

### DIFF
--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+import Prism from 'prismjs';
+
+import 'prismjs/components/prism-python.min.js';
+import 'prismjs/themes/prism-okaidia.css';
+
+
 interface IBlockProps {
   code: string;
   good: boolean;
@@ -29,7 +35,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
   public render() {
     const langclass = "language-" + this.props.language;
     const classes = langclass + " block " + highlightCssClass(this.state.hl);
-    return (<code className={classes} onClick={this.click}>
+    return (<code className={classes} onClick={this.click} ref={this.setCodeRef}>
       {this.props.code}
     </code>);
   }
@@ -39,6 +45,12 @@ class Block extends React.Component<IBlockProps, IBlockState> {
       hl: state.hl !== Highlight.None ? state.hl : (props.good ? Highlight.Good : Highlight.Bad),
     }));
   }
+
+  private setCodeRef = (element: HTMLPreElement) => {
+    if (element !== null) {
+      Prism.highlightElement(element, false);
+    }
+  };
 }
 
 export {Block, IBlockProps};

--- a/src/Snippet.tsx
+++ b/src/Snippet.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react';
 
-
-import Prism from 'prismjs';
-
-import 'prismjs/components/prism-python.min.js';
-import 'prismjs/themes/prism-okaidia.css';
-
 import './snippet.css';
 
 import * as Block from './Block'
-
-Prism.highlightAll();
 
 interface IBlock {
   code: string;


### PR DESCRIPTION
Fixes a bug where when opening a snippet from the home page, the snippet wouldn't be highlighted until reload.