### PR TITLE
Fix bug where highlights would carry over through example switches

### DIFF
--- a/src/Examples.tsx
+++ b/src/Examples.tsx
@@ -48,7 +48,7 @@ class Example extends React.Component<RouteComponentProps<IMatchParams>, {}> {
           <h2 className="title is-4">
             Find the lines that should be changed/fixed
           </h2>
-          <Snippet.Snippet {...GetExample(name)} />
+          <Snippet.Snippet key={name} {...GetExample(name)} />
         </div>
       );
     } else {


### PR DESCRIPTION
An alternate solution would be to make block keys unique across different snippets. I think when React re-renders snippet after we switch examples, it still thinks it's the same one in the same place, and since our block keys are indices it believes them to be the same too. 