### PR TITLE
Series of fixes

### DIFF
--- a/src/Block.test.tsx
+++ b/src/Block.test.tsx
@@ -35,14 +35,14 @@ describe('highlighting', () => {
 
   it('highlights to proper type after click', () => {
     const goodBlockWrapper = shallow( <Block {...goodBlockProps} /> );
-    const badBlockWrapper = shallow( <Block {...badBlockProps} /> );
+    expect(goodBlockWrapper.is('.hidden')).toBe(false);
     goodBlockWrapper.find('code').simulate('click');
-    expect(badBlockWrapper.is('.bad')).toBe(false);
-    expect(goodBlockWrapper.is('.good')).toBe(true);
+    expect(goodBlockWrapper.is('.hidden')).toBe(true);
 
+    const badBlockWrapper = shallow( <Block {...badBlockProps} /> );
+    expect(badBlockWrapper.is('.hidden')).toBe(false);
     badBlockWrapper.find('code').simulate('click');
-    expect(badBlockWrapper.is('.good')).toBe(false);
-    expect(badBlockWrapper.is('.bad')).toBe(true);
+    expect(badBlockWrapper.is('.hidden')).toBe(true);
   });
 
   it('ignore blocks dont respond to clicks', () => {

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -25,9 +25,10 @@ enum Highlight {
 }
 
 function highlightCssClass(h: Highlight, revealed: boolean) {
-  if (!revealed && h !== Highlight.None) {
+  if (!revealed && h !== Highlight.None && h !== Highlight.Ignore) {
     return "hidden";
   }
+
   return Highlight[h].toLowerCase();
 }
 
@@ -49,12 +50,14 @@ function blockTypeToHighlight(blockType: BlockType) {
 class Block extends React.Component<IBlockProps, IBlockState> {
   constructor(props: IBlockProps) {
     super(props);
-    this.state = { hl: props.typ === BlockType.Ignore ? Highlight.Ignore : Highlight.None };
+    this.state = {
+      hl: props.typ === BlockType.Ignore ? Highlight.Ignore : Highlight.None
+    };
   }
 
   public render() {
     const classes = [
-      "language-" + this.props.language,
+      `language-${this.props.language}`,
       "block",
       highlightCssClass(this.state.hl, this.props.locked),
       "is-marginless"
@@ -65,10 +68,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
     }
 
     return (
-      <code
-        className={classes.join(" ")}
-        onClick={this.click}
-      >
+      <code className={classes.join(" ")} onClick={this.click}>
         {this.props.code}
       </code>
     );

--- a/src/Snippet.tsx
+++ b/src/Snippet.tsx
@@ -12,6 +12,7 @@ import './snippet.css';
 Prism.plugins.customClass.prefix('prism--');
 
 interface ISnippetProps {
+  keyPrefix: string; // used to prefix block keys to ensure uniqueness.
   blocks: Block.IBlock[];
   lang: string;
   locked: boolean;
@@ -33,7 +34,11 @@ class Snippet extends React.Component<ISnippetProps, {}> {
     return (
       <pre className={`language-${this.props.lang}`}>
         {this.props.blocks.map((block, ii) =>
-          <Block.Block key={ii} {...this.props.blocks[ii]} language={this.props.lang} locked={this.props.locked} />
+          <Block.Block
+            key={`${this.props.keyPrefix}-${ii}`}
+            {...this.props.blocks[ii]}
+            language={this.props.lang}
+            locked={this.props.locked} />
         )}
       </pre>
     );


### PR DESCRIPTION
Fixed:
* block highlight carry-over bug was reintroduced in previous PR. Fixed now by appending example name to block index (more idiomatic than giving Snippet key, I think).
* examples now reset to pre-submit view. In the last PR, switching to a new example after submitting would bring you to the submit state in the new example.
* Highlight.Ignore still incorrectly highlights the line when you hover, but at least it isn't selected now.
* updated block tests a bit but still aren't up to date. Not enough time remaining.