### PR TITLE
Submission feedback flow

### DIFF
--- a/src/Block.test.tsx
+++ b/src/Block.test.tsx
@@ -7,21 +7,21 @@ describe('highlighting', () => {
     code: "print(\"You had me at hello\")",
     typ: BlockType.Good,
     language: "foo",
-    locked: false
+    submitted: false
   };
 
   const badBlockProps = {
     code: "print(\"You had me at goodbye\")",
     typ: BlockType.Bad,
     language: "bar",
-    locked: false
+    submitted: false
   };
 
   const ignoreBlockProps = {
     code: "print(\"You had me at schmubleck\")",
     typ: BlockType.Ignore,
     language: "schmubleck",
-    locked: false
+    submitted: false
   };
 
   it('has no highlight before click', () => {

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -69,7 +69,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
       classes.push("submitted");
 
       const submittedAnswer = currentAnswer(this.state.hl);
-      // const isCorrect = (submittedAnswer === this.props.typ);
+      let resultClasses = (submittedAnswer === this.props.typ) ? "result-icon" : "result-icon incorrect";
 
       let submittedClasses = classes.join(" ");
       let actualClasses = classes.join(" ");
@@ -78,6 +78,8 @@ class Block extends React.Component<IBlockProps, IBlockState> {
         submittedClasses = submittedClasses + " bad";
         if (this.props.typ === BlockType.Good) {
           actualClasses = actualClasses + " good";
+        } else {
+          resultClasses = "result-icon correct";
         }
       }
 
@@ -90,6 +92,8 @@ class Block extends React.Component<IBlockProps, IBlockState> {
           <code className={submittedClasses} onClick={this.click}>
             {this.props.code}
           </code>
+
+          <span className={resultClasses} />
 
           <code className={actualClasses} onClick={this.click}>
             {this.props.code}

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -51,7 +51,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
     const classes = [
       `language-${this.props.language}`,
       "block",
-      "is-marginless"
+       "is-marginless"
     ]
 
     function currentAnswer(hl: Highlight) : BlockType {
@@ -88,7 +88,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
       }
 
       return (
-        <span className="code-line">
+        <pre className="code-line is-marginless">
           <code className={submittedClasses} onClick={this.click}>
             {this.props.code}
           </code>
@@ -98,7 +98,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
           <code className={actualClasses} onClick={this.click}>
             {this.props.code}
           </code>
-        </span>
+        </pre>
       );
     }
 
@@ -109,11 +109,11 @@ class Block extends React.Component<IBlockProps, IBlockState> {
     }
 
     return (
-      <span className="code-line">
+      <pre className="code-line is-marginless">
         <code className={classes.join(" ")} onClick={this.click}>
           {this.props.code}
         </code>
-      </span>
+      </pre>
     );
   }
 

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -102,10 +102,8 @@ class Block extends React.Component<IBlockProps, IBlockState> {
       );
     }
 
-    if (this.state.hl !== Highlight.None && this.state.hl !== Highlight.Ignore) {
-      classes.push("hidden");
-    } else {
-      classes.push("none");
+    if (this.state.hl !== Highlight.Ignore) {
+      classes.push(this.state.hl === Highlight.None ? "none" : "hidden");
     }
 
     return (

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -13,7 +13,7 @@ interface IBlock {
 
 interface IBlockProps extends IBlock {
   language: string;
-  locked: boolean;
+  submitted: boolean;
 }
 
 enum Highlight {
@@ -59,12 +59,12 @@ class Block extends React.Component<IBlockProps, IBlockState> {
     const classes = [
       `language-${this.props.language}`,
       "block",
-      highlightCssClass(this.state.hl, this.props.locked),
+      highlightCssClass(this.state.hl, this.props.submitted),
       "is-marginless"
     ]
 
-    if (this.props.locked) {
-      classes.push("locked");
+    if (this.props.submitted) {
+      classes.push("submitted");
     }
 
     return (
@@ -76,7 +76,7 @@ class Block extends React.Component<IBlockProps, IBlockState> {
 
   private click = () => {
     this.setState((state: IBlockState, props: IBlockProps) => {
-      if (this.props.locked) {
+      if (this.props.submitted) {
         return state;
       }
 

--- a/src/Block.tsx
+++ b/src/Block.tsx
@@ -24,14 +24,6 @@ enum Highlight {
   Bad,
 }
 
-function highlightCssClass(h: Highlight, revealed: boolean) {
-  if (!revealed && h !== Highlight.None && h !== Highlight.Ignore) {
-    return "hidden";
-  }
-
-  return Highlight[h].toLowerCase();
-}
-
 interface IBlockState {
   hl: Highlight;
 }
@@ -59,18 +51,65 @@ class Block extends React.Component<IBlockProps, IBlockState> {
     const classes = [
       `language-${this.props.language}`,
       "block",
-      highlightCssClass(this.state.hl, this.props.submitted),
       "is-marginless"
     ]
 
+    function currentAnswer(hl: Highlight) : BlockType {
+      switch(hl) {
+      case Highlight.None:
+        return BlockType.Good;
+      case Highlight.Ignore:
+        return BlockType.Ignore;
+      default:
+        return BlockType.Bad;
+      }
+    }
+
     if (this.props.submitted) {
       classes.push("submitted");
+
+      const submittedAnswer = currentAnswer(this.state.hl);
+      // const isCorrect = (submittedAnswer === this.props.typ);
+
+      let submittedClasses = classes.join(" ");
+      let actualClasses = classes.join(" ");
+
+      if (submittedAnswer === BlockType.Bad) {
+        submittedClasses = submittedClasses + " bad";
+        if (this.props.typ === BlockType.Good) {
+          actualClasses = actualClasses + " good";
+        }
+      }
+
+      if (this.props.typ === BlockType.Bad) {
+        actualClasses = actualClasses + " bad";
+      }
+
+      return (
+        <span className="code-line">
+          <code className={submittedClasses} onClick={this.click}>
+            {this.props.code}
+          </code>
+
+          <code className={actualClasses} onClick={this.click}>
+            {this.props.code}
+          </code>
+        </span>
+      );
+    }
+
+    if (this.state.hl !== Highlight.None && this.state.hl !== Highlight.Ignore) {
+      classes.push("hidden");
+    } else {
+      classes.push("none");
     }
 
     return (
-      <code className={classes.join(" ")} onClick={this.click}>
-        {this.props.code}
-      </code>
+      <span className="code-line">
+        <code className={classes.join(" ")} onClick={this.click}>
+          {this.props.code}
+        </code>
+      </span>
     );
   }
 

--- a/src/Examples.tsx
+++ b/src/Examples.tsx
@@ -42,21 +42,6 @@ function GetExample(name: string) {
   return ParseExample(Registry[name]);
 }
 
-function GetSolution(name: string) {
-  const ex = Registry[name];
-  if ('solution' in ex) {
-    return {
-      blocks: [{
-        code: ex.solution,
-        typ: Block.BlockType.Ignore,
-      }],
-      lang: ex.lang,
-      submitted: true,
-    };
-  }
-  return GetExample(name);
-}
-
 interface IMatchParams {
   name: string;
 }
@@ -91,16 +76,12 @@ class Example extends React.Component<IExampleProps, IExampleState> {
     return (
       <div>
         <h2 className="title is-4">
-          {this.state.submitted ?
-            "Submitted code:" :
-            `Example ${name}:`}
+          {`${name}:`}
         </h2>
         <Snippet.Snippet {...example} keyPrefix={name} submitted={this.state.submitted}/>
-        {this.state.submitted ?  (
-          <Snippet.Snippet {...GetSolution(name)} keyPrefix={name} submitted={true} />
-        ) : (
+        {!this.state.submitted &&
           <button className="button is-primary" onClick={this.submit}>Submit</button>
-        )}
+        }
       </div>
     );
   }

--- a/src/Examples.tsx
+++ b/src/Examples.tsx
@@ -14,7 +14,7 @@ interface IExample {
 interface IParsedExample {
   blocks: Block.IBlock[];
   lang: string;
-  locked: boolean;
+  submitted: boolean;
 };
 
 function ParseExample(ex: IExample): IParsedExample {
@@ -34,7 +34,7 @@ function ParseExample(ex: IExample): IParsedExample {
   return {
     blocks,
     lang: ex.lang,
-    locked: false
+    submitted: false
   };
 }
 
@@ -51,7 +51,7 @@ function GetSolution(name: string) {
         typ: Block.BlockType.Ignore,
       }],
       lang: ex.lang,
-      locked: true,
+      submitted: true,
     };
   }
   return GetExample(name);
@@ -95,9 +95,9 @@ class Example extends React.Component<IExampleProps, IExampleState> {
             "Submitted code:" :
             `Example ${name}:`}
         </h2>
-        <Snippet.Snippet {...example} keyPrefix={name} locked={this.state.submitted}/>
+        <Snippet.Snippet {...example} keyPrefix={name} submitted={this.state.submitted}/>
         {this.state.submitted ?  (
-          <Snippet.Snippet {...GetSolution(name)} keyPrefix={name} locked={true} />
+          <Snippet.Snippet {...GetSolution(name)} keyPrefix={name} submitted={true} />
         ) : (
           <button className="button is-primary" onClick={this.submit}>Submit</button>
         )}

--- a/src/Snippet.tsx
+++ b/src/Snippet.tsx
@@ -15,7 +15,7 @@ interface ISnippetProps {
   keyPrefix: string; // used to prefix block keys to ensure uniqueness.
   blocks: Block.IBlock[];
   lang: string;
-  locked: boolean;
+  submitted: boolean;
 }
 
 class Snippet extends React.Component<ISnippetProps, {}> {
@@ -38,7 +38,7 @@ class Snippet extends React.Component<ISnippetProps, {}> {
             key={`${this.props.keyPrefix}-${ii}`}
             {...this.props.blocks[ii]}
             language={this.props.lang}
-            locked={this.props.locked} />
+            submitted={this.props.submitted} />
         )}
       </pre>
     );

--- a/src/examples/BasicDRY.tsx
+++ b/src/examples/BasicDRY.tsx
@@ -5,7 +5,7 @@ const ex = {
 # convert temperatures from farenheit to celsius
 
 @Btemperature1 = 40.0
-temperature2 = 50.0
+@Btemperature2 = 50.0
 @N
 @Bconverted_temperature1 = (temperature1 - 32) * 5.0/9
 @Bprint(temperature1, "degrees farenheit is", converted_temperature1, "degrees Celsius")

--- a/src/examples/BasicLogic.tsx
+++ b/src/examples/BasicLogic.tsx
@@ -2,10 +2,10 @@ const ex = {
     lang: "python",
     code:
 `
-def calculate_shipping(state):
+@Gdef calculate_shipping(state):
 @B    if not (state != 'AK' and state != 'HI'):
-        return 30.0
-    return 20.0 
+@G        return 30.0
+@G    return 20.0
 `,
     feedback: "That logic up there is a bit hard to read. Fortunately, it's equivalent to check whether state is in the list ['AK', 'HI']. We think this is a lot easier to read.",
 };

--- a/src/prism-okaidia-with-prefix.css
+++ b/src/prism-okaidia-with-prefix.css
@@ -6,60 +6,62 @@
 
 code[class*="language-"],
 pre[class*="language-"] {
-	color: #f8f8f2;
-	background: none;
-	text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	text-align: left;
-	white-space: pre;
-	word-spacing: normal;
-	word-break: normal;
-	word-wrap: normal;
-	line-height: 1.5;
+    color: #f8f8f2;
+    background: none;
+    text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    text-align: left;
+    white-space: pre;
+    word-spacing: normal;
+    word-break: normal;
+    word-wrap: normal;
+    line-height: 1.5;
 
-	-moz-tab-size: 4;
-	-o-tab-size: 4;
-	tab-size: 4;
+    -moz-tab-size: 4;
+    -o-tab-size: 4;
+    tab-size: 4;
 
-	-webkit-hyphens: none;
-	-moz-hyphens: none;
-	-ms-hyphens: none;
-	hyphens: none;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    -ms-hyphens: none;
+    hyphens: none;
 }
 
 /* Code blocks */
 pre[class*="language-"] {
-	padding: 1em;
-	margin: .5em 0;
-	overflow: auto;
-	border-radius: 0.3em;
+    padding: 1em 0em;
+    margin: .5em 0;
+    overflow: auto;
 }
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-	background: #272822;
+    background: #272822;
+}
+
+pre[class*="language-"] {
+    border-radius: 0.3em;
 }
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-	padding: .1em;
-	border-radius: .3em;
-	white-space: normal;
+    padding: 0em 1em;
+    white-space: normal;
 }
 
 .prism--token.prism--comment,
 .prism--token.prism--prolog,
 .prism--token.prism--doctype,
 .prism--token.prism--cdata {
-	color: slategray;
+    color: slategray;
 }
 
 .prism--token.prism--punctuation {
-	color: #f8f8f2;
+    color: #f8f8f2;
 }
 
 .prism--namespace {
-	opacity: .7;
+    opacity: .7;
 }
 
 .prism--token.prism--property,
@@ -67,12 +69,12 @@ pre[class*="language-"] {
 .prism--token.prism--constant,
 .prism--token.prism--symbol,
 .prism--token.prism--deleted {
-	color: #f92672;
+    color: #f92672;
 }
 
 .prism--token.prism--boolean,
 .prism--token.prism--number {
-	color: #ae81ff;
+    color: #ae81ff;
 }
 
 .prism--token.prism--selector,
@@ -81,7 +83,7 @@ pre[class*="language-"] {
 .prism--token.prism--char,
 .prism--token.prism--builtin,
 .prism--token.prism--inserted {
-	color: #a6e22e;
+    color: #a6e22e;
 }
 
 .prism--token.prism--operator,
@@ -90,33 +92,33 @@ pre[class*="language-"] {
 .language-css .prism--token.prism--string,
 .style .prism--token.prism--string,
 .prism--token.prism--variable {
-	color: #f8f8f2;
+    color: #f8f8f2;
 }
 
 .prism--token.prism--atrule,
 .prism--token.prism--attr-value,
 .prism--token.prism--function,
 .prism--token.prism--class-name {
-	color: #e6db74;
+    color: #e6db74;
 }
 
 .prism--token.prism--keyword {
-	color: #66d9ef;
+    color: #66d9ef;
 }
 
 .prism--token.prism--regex,
 .prism--token.prism--important {
-	color: #fd971f;
+    color: #fd971f;
 }
 
 .prism--token.prism--important,
 .prism--token.prism--bold {
-	font-weight: bold;
+    font-weight: bold;
 }
 .prism--token.prism--italic {
-	font-style: italic;
+    font-style: italic;
 }
 
 .prism--token.prism--entity {
-	cursor: help;
+    cursor: help;
 }

--- a/src/snippet.css
+++ b/src/snippet.css
@@ -3,7 +3,7 @@ code.block {
     border-radius: 5px;
     display: block;
 }
-code.block.none:not(.locked):hover, code.block.hidden:hover {
+code.block.none:not(.submitted):hover, code.block.hidden:hover {
     background: #4c4e41;
     cursor: grab;
 }

--- a/src/snippet.css
+++ b/src/snippet.css
@@ -1,7 +1,10 @@
+span.code-line {
+    width: 100%;
+    display: block;
+}
 code.block {
     width: 100%;
-    border-radius: 5px;
-    display: block;
+    display: inline-block;
 }
 code.block.none:not(.submitted):hover, code.block.hidden:hover {
     background: #4c4e41;
@@ -15,4 +18,8 @@ code.block.bad {
 }
 code.block.good {
     background: #3dea73a3;
+}
+code.block.submitted {
+    display: inline-block;
+    width: 50%;
 }

--- a/src/snippet.css
+++ b/src/snippet.css
@@ -1,10 +1,15 @@
-span.code-line {
+pre.code-line {
     width: 100%;
     display: block;
+    border-radius: 0em;
+    padding: 0em;
+    margin: 0em;
+    overflow: hidden;
 }
 code.block {
     width: 100%;
     display: inline-block;
+    padding: 0em 1em;
 }
 code.block.none:not(.submitted):hover, code.block.hidden:hover {
     background: #f8f8f233;

--- a/src/snippet.css
+++ b/src/snippet.css
@@ -14,14 +14,26 @@ code.block.hidden {
     background: #f9267233;
 }
 code.block.bad {
-    /*background: #6600009c;*/
     background: #f9267233;
 }
 code.block.good {
-    /*background: #0077339c;*/
     background: #a6e22e33;
 }
 code.block.submitted {
     display: inline-block;
-    width: 50%;
+    width: 47%;
+}
+span.result-icon {
+    display: inline-block;
+    width: 6%;
+    text-align: center;
+}
+span.result-icon.incorrect:before {
+    color: #f92672;
+    content: "⨉";
+    font-size: 0.75em;
+}
+span.result-icon.correct:before {
+    color: #a6e22e;
+    content: "✓";
 }

--- a/src/snippet.css
+++ b/src/snippet.css
@@ -7,17 +7,19 @@ code.block {
     display: inline-block;
 }
 code.block.none:not(.submitted):hover, code.block.hidden:hover {
-    background: #4c4e41;
+    background: #f8f8f233;
     cursor: grab;
 }
 code.block.hidden {
-    background: #554444;
+    background: #f9267233;
 }
 code.block.bad {
-    background: #ff00009c;
+    /*background: #6600009c;*/
+    background: #f9267233;
 }
 code.block.good {
-    background: #3dea73a3;
+    /*background: #0077339c;*/
+    background: #a6e22e33;
 }
 code.block.submitted {
     display: inline-block;


### PR DESCRIPTION
- Cosmetic improvements (colour and padding)
- Implemented the line-by-line visual feedback as mocked up in wireframes
- Removed (for the moment!) the corrected solution after submission, since it wasn't in line with the original wireframes and would have required a fairly time-consuming rework to include

See https://savoie.github.io/yiddish-cornstarch/#/

TODO: restore the correct solution (click-through to see, or hover for info), add headers to both columns, add some kind of count of the total lines correct, fix the tests I broke.